### PR TITLE
Allow manual execution of all GitHub workflows

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -2,6 +2,7 @@ name: CMake (Linux)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -2,6 +2,7 @@ name: CMake (macos)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -2,6 +2,7 @@ name: CMake (Windows, msys2)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**

--- a/.github/workflows/codeql_linux.yml
+++ b/.github/workflows/codeql_linux.yml
@@ -2,6 +2,7 @@ name: CodeQL Analysis (Linux)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**

--- a/.github/workflows/codeql_macos.yml
+++ b/.github/workflows/codeql_macos.yml
@@ -2,6 +2,7 @@ name: CodeQL Analysis (macos)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**

--- a/.github/workflows/codeql_windows_msys2.yml
+++ b/.github/workflows/codeql_windows_msys2.yml
@@ -2,6 +2,7 @@ name: CodeQL Analysis (Windows, msys2)
 
 on:
 
+  workflow_dispatch:
   push:
     paths:
       - src/**


### PR DESCRIPTION
## Summary
- enable manual execution for each CI workflow via `workflow_dispatch`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68544d16da9c832f8bc7b22f94dc465b