### PR TITLE
Show CPU info in machine list

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -363,6 +363,8 @@ extern int         machine_count(void);
 extern int         machine_available(int m);
 extern const char *machine_getname(void);
 extern const char *machine_getname_ex(int m);
+extern int         machine_get_type_year(int type);
+extern const char *machine_get_typical_cpu_name(int m);
 extern const char *machine_get_internal_name(void);
 extern const char *machine_get_nvr_name(void);
 extern int         machine_get_machine_from_internal_name(const char *s);

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -176,7 +176,12 @@ SettingsMachine::on_comboBoxMachineType_currentIndexChanged(int index)
         for (int i = 0; i < machine_count(); ++i) {
             if ((machine_get_type(i) == ui->comboBoxMachineType->currentData().toInt()) &&
                 machine_available(i)) {
-                int row = Models::AddEntry(model, machines[i].name, i);
+                QString name = QString::fromUtf8(machines[i].name);
+                int     year = machine_get_type_year(machine_get_type(i));
+                if (year >= 1990)
+                    name += QString(" (%1)").arg(machine_get_typical_cpu_name(i));
+
+                int row = Models::AddEntry(model, name, i);
                 if (i == machine)
                     selectedMachineRow = row - removeRows;
             }


### PR DESCRIPTION
## Summary
- display simplified processor for machines from 1990 onward
- add helpers for machine year and CPU info
- refine CPU label generation

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`


------
https://chatgpt.com/codex/tasks/task_e_6854a49eda24832f9d60ed435ca109c5