### PR TITLE
Add turbo mode

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -212,6 +212,7 @@ int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether
                                                                          also apply when maximized. */
 int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
                                                                          loss */
+int      turbo_mode                             = 0;              /* Run emulator at maximum speed */
 int      hook_enabled                           = 1;              /* (C) Keyboard hook is enabled */
 int      test_mode                              = 0;              /* (C) Test mode */
 char     uuid[MAX_UUID_LEN]                     = { '\0' };       /* (C) UUID or machine identifier */

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -162,6 +162,7 @@ extern int    fixed_size_x;
 extern int    fixed_size_y;
 extern int    sound_muted;                  /* (C) Is sound muted? */
 extern int    do_auto_pause;                /* (C) Auto-pause the emulator on focus loss */
+extern int    turbo_mode;                   /* Run emulator at maximum speed */
 extern int    auto_paused;
 extern double mouse_sensitivity;            /* (C) Mouse sensitivity scale */
 #ifdef _Atomic

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -449,7 +449,26 @@ main_thread_fn()
 #endif
             drawits += static_cast<int>(new_time - old_time);
         old_time = new_time;
-        if (drawits > 0 && !dopause) {
+        if (turbo_mode && !dopause) {
+#ifdef USE_INSTRUMENT
+            uint64_t start_time = elapsed_timer.nsecsElapsed();
+#endif
+            pc_run();
+#ifdef USE_INSTRUMENT
+            if (instru_enabled) {
+                uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
+                uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
+                printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
+                if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
+                    break;
+            }
+#endif
+            if (++frames >= 200 && nvr_dosave) {
+                qt_nvr_save();
+                nvr_dosave = 0;
+                frames     = 0;
+            }
+        } else if (drawits > 0 && !dopause) {
             /* Yes, so do one frame now. */
             drawits -= 10;
             if (drawits > 50)

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -674,6 +674,9 @@ MainWindow::MainWindow(QWidget *parent)
     if (do_auto_pause > 0) {
         ui->actionAuto_pause->setChecked(true);
     }
+    if (turbo_mode > 0) {
+        ui->actionTurbo_mode->setChecked(true);
+    }
 
 #ifdef Q_OS_MACOS
     ui->actionCtrl_Alt_Del->setShortcutVisibleInContextMenu(true);
@@ -1100,6 +1103,13 @@ void
 MainWindow::on_actionPause_triggered()
 {
     plat_pause(dopause ^ 1);
+}
+
+void
+MainWindow::on_actionTurbo_mode_triggered()
+{
+    turbo_mode ^= 1;
+    ui->actionTurbo_mode->setChecked(turbo_mode > 0 ? true : false);
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -77,6 +77,7 @@ private slots:
     void on_actionExit_triggered();
     void on_actionAuto_pause_triggered();
     void on_actionPause_triggered();
+    void on_actionTurbo_mode_triggered();
     void on_actionCtrl_Alt_Del_triggered();
     void on_actionCtrl_Alt_Esc_triggered();
     void on_actionHard_Reset_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -75,6 +75,7 @@
     <addaction name="menuTablet_tool"/>
     <addaction name="separator"/>
     <addaction name="actionPause"/>
+    <addaction name="actionTurbo_mode"/>
     <addaction name="separator"/>
     <addaction name="actionHard_Reset"/>
     <addaction name="actionCtrl_Alt_Del"/>
@@ -355,6 +356,14 @@
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionTurbo_mode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Turbo mode</string>
    </property>
   </action>
   <action name="actionExit">

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -563,7 +563,14 @@ main_thread(UNUSED(void *param))
 #endif
             drawits += (new_time - old_time);
         old_time = new_time;
-        if (drawits > 0 && !dopause) {
+        if (turbo_mode && !dopause) {
+            pc_run();
+            if (++frames >= 200 && nvr_dosave) {
+                nvr_save();
+                nvr_dosave = 0;
+                frames     = 0;
+            }
+        } else if (drawits > 0 && !dopause) {
             /* Yes, so do one frame now. */
             drawits -= 10;
             if (drawits > 50)


### PR DESCRIPTION
## Summary
- add a `turbo_mode` variable
- expose `turbo_mode` in the UI
- implement turbo loop in Qt and Unix backends
- include toggle for turbo mode in the Action menu

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`

------
https://chatgpt.com/codex/tasks/task_e_6854abd2ff00832fb58b033eb82bd194