### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -1,0 +1,32 @@
+name: Release Artifacts
+
+on:
+  workflow_run:
+    workflows:
+      - "CMake (Linux)"
+      - "CMake (macos)"
+      - "CMake (Windows, msys2)"
+    types:
+      - completed
+
+jobs:
+  upload-release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts from run
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: gha-${{ github.event.workflow_run.head_sha }}
+          name: Automated build for ${{ github.event.workflow_run.head_sha }}
+          generate_release_notes: true
+          files: artifacts/**
+          token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite_files: true
+          append_body: true


### PR DESCRIPTION
## Summary
- upload successful artifacts from Linux, macOS, and Windows builds as release assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854b5a3cf40832f908469424a3e7cf5