### PR TITLE
Fix release workflow packaging

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -20,13 +20,28 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
+      - name: Prepare release archives
+        run: |
+          mkdir -p release
+          cwd=$(pwd)
+          for d in artifacts/*; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            if [ -d "$d/build/artifacts" ]; then
+              content="$d/build/artifacts"
+            else
+              content="$d"
+            fi
+            (cd "$content" && zip -r "$cwd/release/${name}.zip" .)
+          done
+
       - name: Create or update release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: gha-${{ github.event.workflow_run.head_sha }}
           name: Automated build for ${{ github.event.workflow_run.head_sha }}
           generate_release_notes: true
-          files: artifacts/**
+          files: release/*.zip
           token: ${{ secrets.GITHUB_TOKEN }}
           overwrite_files: true
           append_body: true


### PR DESCRIPTION
## Summary
- fix release workflow to package each artifact individually as a ZIP file
- upload only the zipped build artifacts to the release

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6854bc16fdb4832f9f5975e7d820a99d