### PR TITLE
Release packaging tweaks

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -32,7 +32,29 @@ jobs:
             else
               content="$d"
             fi
-            (cd "$content" && zip -r "$cwd/release/${name}.zip" .)
+
+            target=""
+            if [ -f "$content/86Box.exe" ]; then
+              target="$content/86Box.exe"
+            elif [ -f "$content/bin/86Box.exe" ]; then
+              target="$content/bin/86Box.exe"
+            elif [ -f "$content/86Box" ]; then
+              target="$content/86Box"
+            elif [ -f "$content/bin/86Box" ]; then
+              target="$content/bin/86Box"
+            elif [ -d "$content/86Box.app" ]; then
+              target="$content/86Box.app"
+            fi
+
+            if [ -z "$target" ]; then
+              echo "Unable to find binary in $content" >&2
+              continue
+            fi
+
+            tmpdir=$(mktemp -d)
+            cp -r "$target" "$tmpdir/"
+            (cd "$tmpdir" && zip -r "$cwd/release/${name}.zip" .)
+            rm -rf "$tmpdir"
           done
 
       - name: Create or update release


### PR DESCRIPTION
## Summary
- refine `release_artifacts.yml` to only include the built binary in each zip archive

## Testing
- `git commit -m "refactor: package binaries only"`

------
https://chatgpt.com/codex/tasks/task_e_6854c0300e88832fb52b1704ca16db07