### PR TITLE
Add manual workflow to trigger all builds

### DIFF
--- a/.github/workflows/run_all_builds.yml
+++ b/.github/workflows/run_all_builds.yml
@@ -1,0 +1,30 @@
+name: Run All Target Builds
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger build workflows
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const workflows = [
+              'cmake_linux.yml',
+              'cmake_macos.yml',
+              'cmake_windows_msys2.yml'
+            ];
+            const ref = context.ref;
+            for (const wf of workflows) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: wf,
+                ref: ref
+              });
+              core.info(`Dispatched ${wf} for ${ref}`);
+            }
+


### PR DESCRIPTION
## Summary
- create a `run_all_builds` workflow that dispatches the platform build jobs

## Testing
- `yamllint .github/workflows/run_all_builds.yml`

------
https://chatgpt.com/codex/tasks/task_e_6854c2169ff0832f8e502a03c5b4c8c3