### PR TITLE
Add slow turbo feature

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -213,6 +213,7 @@ int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether
 int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
                                                                          loss */
 int      turbo_mode                             = 0;              /* Run emulator at maximum speed */
+int      turbo_slow_cycles                      = 0;              /* Delay cycles between turbo steps */
 int      hook_enabled                           = 1;              /* (C) Keyboard hook is enabled */
 int      test_mode                              = 0;              /* (C) Test mode */
 char     uuid[MAX_UUID_LEN]                     = { '\0' };       /* (C) UUID or machine identifier */

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -163,6 +163,7 @@ extern int    fixed_size_y;
 extern int    sound_muted;                  /* (C) Is sound muted? */
 extern int    do_auto_pause;                /* (C) Auto-pause the emulator on focus loss */
 extern int    turbo_mode;                   /* Run emulator at maximum speed */
+extern int    turbo_slow_cycles;            /* Delay cycles between turbo steps */
 extern int    auto_paused;
 extern double mouse_sensitivity;            /* (C) Mouse sensitivity scale */
 #ifdef _Atomic

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -450,9 +450,9 @@ main_thread_fn()
             drawits += static_cast<int>(new_time - old_time);
         old_time = new_time;
         if (turbo_mode && !dopause) {
-#ifdef USE_INSTRUMENT
+            #ifdef USE_INSTRUMENT
             uint64_t start_time = elapsed_timer.nsecsElapsed();
-#endif
+            #endif
             pc_run();
 #ifdef USE_INSTRUMENT
             if (instru_enabled) {
@@ -468,6 +468,33 @@ main_thread_fn()
                 nvr_dosave = 0;
                 frames     = 0;
             }
+        } else if (turbo_slow_cycles > 0 && !dopause) {
+            static int slow_counter = 0;
+#ifdef USE_INSTRUMENT
+            uint64_t start_time = 0;
+#endif
+            if (slow_counter == 0) {
+#ifdef USE_INSTRUMENT
+                start_time = elapsed_timer.nsecsElapsed();
+#endif
+                pc_run();
+#ifdef USE_INSTRUMENT
+                if (instru_enabled) {
+                    uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
+                    uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
+                    printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
+                    if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
+                        break;
+                }
+#endif
+                if (++frames >= 200 && nvr_dosave) {
+                    qt_nvr_save();
+                    nvr_dosave = 0;
+                    frames     = 0;
+                }
+            }
+            if (++slow_counter > turbo_slow_cycles)
+                slow_counter = 0;
         } else if (drawits > 0 && !dopause) {
             /* Yes, so do one frame now. */
             drawits -= 10;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -160,6 +160,8 @@ keyb_filter(BMessage *message, BHandler **target, BMessageFilter *filter)
 static BMessageFilter *filter;
 #endif
 
+static void update_slow_turbo_checkboxes(Ui::MainWindow *ui, QAction *selected, int value);
+
 extern void     qt_mouse_capture(int);
 extern "C" void qt_blit(int x, int y, int w, int h, int monitor_index);
 
@@ -676,7 +678,31 @@ MainWindow::MainWindow(QWidget *parent)
     }
     if (turbo_mode > 0) {
         ui->actionTurbo_mode->setChecked(true);
+        ui->menuSlow_turbo->setEnabled(false);
     }
+    switch (turbo_slow_cycles) {
+        default:
+            ui->actionSlow_Turbo_Off->setChecked(true);
+            break;
+        case 1:
+            ui->actionSlow_Turbo_1_cycle->setChecked(true);
+            break;
+        case 2:
+            ui->actionSlow_Turbo_2_cycles->setChecked(true);
+            break;
+        case 3:
+            ui->actionSlow_Turbo_3_cycles->setChecked(true);
+            break;
+        case 4:
+            ui->actionSlow_Turbo_4_cycles->setChecked(true);
+            break;
+    }
+    actGroup = new QActionGroup(this);
+    actGroup->addAction(ui->actionSlow_Turbo_Off);
+    actGroup->addAction(ui->actionSlow_Turbo_1_cycle);
+    actGroup->addAction(ui->actionSlow_Turbo_2_cycles);
+    actGroup->addAction(ui->actionSlow_Turbo_3_cycles);
+    actGroup->addAction(ui->actionSlow_Turbo_4_cycles);
 
 #ifdef Q_OS_MACOS
     ui->actionCtrl_Alt_Del->setShortcutVisibleInContextMenu(true);
@@ -1110,6 +1136,37 @@ MainWindow::on_actionTurbo_mode_triggered()
 {
     turbo_mode ^= 1;
     ui->actionTurbo_mode->setChecked(turbo_mode > 0 ? true : false);
+    ui->menuSlow_turbo->setEnabled(turbo_mode == 0);
+}
+
+void
+MainWindow::on_actionSlow_Turbo_Off_triggered()
+{
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_Off, 0);
+}
+
+void
+MainWindow::on_actionSlow_Turbo_1_cycle_triggered()
+{
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_1_cycle, 1);
+}
+
+void
+MainWindow::on_actionSlow_Turbo_2_cycles_triggered()
+{
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_2_cycles, 2);
+}
+
+void
+MainWindow::on_actionSlow_Turbo_3_cycles_triggered()
+{
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_3_cycles, 3);
+}
+
+void
+MainWindow::on_actionSlow_Turbo_4_cycles_triggered()
+{
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_4_cycles, 4);
 }
 
 void
@@ -1701,6 +1758,18 @@ update_scaled_checkboxes(Ui::MainWindow *ui, QAction *selected)
             video_force_resize_set_monitor(1, i);
     }
     config_save();
+}
+
+static void
+update_slow_turbo_checkboxes(Ui::MainWindow *ui, QAction *selected, int value)
+{
+    ui->actionSlow_Turbo_Off->setChecked(ui->actionSlow_Turbo_Off == selected);
+    ui->actionSlow_Turbo_1_cycle->setChecked(ui->actionSlow_Turbo_1_cycle == selected);
+    ui->actionSlow_Turbo_2_cycles->setChecked(ui->actionSlow_Turbo_2_cycles == selected);
+    ui->actionSlow_Turbo_3_cycles->setChecked(ui->actionSlow_Turbo_3_cycles == selected);
+    ui->actionSlow_Turbo_4_cycles->setChecked(ui->actionSlow_Turbo_4_cycles == selected);
+
+    turbo_slow_cycles = value;
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -78,6 +78,11 @@ private slots:
     void on_actionAuto_pause_triggered();
     void on_actionPause_triggered();
     void on_actionTurbo_mode_triggered();
+    void on_actionSlow_Turbo_Off_triggered();
+    void on_actionSlow_Turbo_1_cycle_triggered();
+    void on_actionSlow_Turbo_2_cycles_triggered();
+    void on_actionSlow_Turbo_3_cycles_triggered();
+    void on_actionSlow_Turbo_4_cycles_triggered();
     void on_actionCtrl_Alt_Del_triggered();
     void on_actionCtrl_Alt_Esc_triggered();
     void on_actionHard_Reset_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -68,6 +68,16 @@
      <addaction name="actionPen"/>
      <addaction name="actionCursor_Puck"/>
     </widget>
+    <widget class="QMenu" name="menuSlow_turbo">
+     <property name="title">
+      <string>Slow Turbo</string>
+     </property>
+     <addaction name="actionSlow_Turbo_Off"/>
+     <addaction name="actionSlow_Turbo_1_cycle"/>
+     <addaction name="actionSlow_Turbo_2_cycles"/>
+     <addaction name="actionSlow_Turbo_3_cycles"/>
+     <addaction name="actionSlow_Turbo_4_cycles"/>
+    </widget>
     <addaction name="actionAuto_pause"/>
     <addaction name="separator"/>
     <addaction name="actionKeyboard_requires_capture"/>
@@ -76,6 +86,7 @@
     <addaction name="separator"/>
     <addaction name="actionPause"/>
     <addaction name="actionTurbo_mode"/>
+    <addaction name="menuSlow_turbo"/>
     <addaction name="separator"/>
     <addaction name="actionHard_Reset"/>
     <addaction name="actionCtrl_Alt_Del"/>
@@ -358,14 +369,54 @@
     <bool>false</bool>
    </property>
   </action>
-  <action name="actionTurbo_mode">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Turbo mode</string>
-   </property>
-  </action>
+    <action name="actionTurbo_mode">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Turbo mode</string>
+     </property>
+    </action>
+    <action name="actionSlow_Turbo_Off">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Off</string>
+     </property>
+    </action>
+    <action name="actionSlow_Turbo_1_cycle">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>1 Cycle</string>
+     </property>
+    </action>
+    <action name="actionSlow_Turbo_2_cycles">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>2 Cycles</string>
+     </property>
+    </action>
+    <action name="actionSlow_Turbo_3_cycles">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>3 Cycles</string>
+     </property>
+    </action>
+    <action name="actionSlow_Turbo_4_cycles">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>4 Cycles</string>
+     </property>
+    </action>
   <action name="actionExit">
    <property name="text">
     <string>Exit</string>

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -570,6 +570,18 @@ main_thread(UNUSED(void *param))
                 nvr_dosave = 0;
                 frames     = 0;
             }
+        } else if (turbo_slow_cycles > 0 && !dopause) {
+            static int slow_counter = 0;
+            if (slow_counter == 0) {
+                pc_run();
+                if (++frames >= 200 && nvr_dosave) {
+                    nvr_save();
+                    nvr_dosave = 0;
+                    frames     = 0;
+                }
+            }
+            if (++slow_counter > turbo_slow_cycles)
+                slow_counter = 0;
         } else if (drawits > 0 && !dopause) {
             /* Yes, so do one frame now. */
             drawits -= 10;


### PR DESCRIPTION
## Summary
- add new `turbo_slow_cycles` option and hook it into CPU loops
- expose Slow Turbo submenu in the Action menu with delay options
- disable Slow Turbo while full Turbo mode is enabled

## Testing
- `cmake --preset regular`
- `cmake --build build/regular`


------
https://chatgpt.com/codex/tasks/task_e_68556383e4e0832fba21296a566f6d4f