### PR TITLE
Update slow turbo to cycle skip modes

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -213,7 +213,7 @@ int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether
 int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
                                                                          loss */
 int      turbo_mode                             = 0;              /* Run emulator at maximum speed */
-int      turbo_slow_cycles                      = 0;              /* Delay cycles between turbo steps */
+int      turbo_slow_cycles                      = 0;              /* Cycle skip count when turbo is off */
 int      hook_enabled                           = 1;              /* (C) Keyboard hook is enabled */
 int      test_mode                              = 0;              /* (C) Test mode */
 char     uuid[MAX_UUID_LEN]                     = { '\0' };       /* (C) UUID or machine identifier */
@@ -1573,7 +1573,7 @@ exec_mode_string(void)
     if (turbo_mode)
         return L"Turbo";
     if (turbo_slow_cycles > 0)
-        return L"Slow turbo";
+        return L"Cycle skip";
     return L"Normal";
 }
 

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -163,7 +163,7 @@ extern int    fixed_size_y;
 extern int    sound_muted;                  /* (C) Is sound muted? */
 extern int    do_auto_pause;                /* (C) Auto-pause the emulator on focus loss */
 extern int    turbo_mode;                   /* Run emulator at maximum speed */
-extern int    turbo_slow_cycles;            /* Delay cycles between turbo steps */
+extern int    turbo_slow_cycles;            /* Cycle skip count when turbo is off */
 extern int    auto_paused;
 extern double mouse_sensitivity;            /* (C) Mouse sensitivity scale */
 #ifdef _Atomic

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -687,13 +687,13 @@ MainWindow::MainWindow(QWidget *parent)
         case 1:
             ui->actionSlow_Turbo_1_cycle->setChecked(true);
             break;
-        case 2:
+        case 5:
             ui->actionSlow_Turbo_2_cycles->setChecked(true);
             break;
-        case 3:
+        case 10:
             ui->actionSlow_Turbo_3_cycles->setChecked(true);
             break;
-        case 4:
+        case 25:
             ui->actionSlow_Turbo_4_cycles->setChecked(true);
             break;
     }
@@ -1154,19 +1154,19 @@ MainWindow::on_actionSlow_Turbo_1_cycle_triggered()
 void
 MainWindow::on_actionSlow_Turbo_2_cycles_triggered()
 {
-    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_2_cycles, 2);
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_2_cycles, 5);
 }
 
 void
 MainWindow::on_actionSlow_Turbo_3_cycles_triggered()
 {
-    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_3_cycles, 3);
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_3_cycles, 10);
 }
 
 void
 MainWindow::on_actionSlow_Turbo_4_cycles_triggered()
 {
-    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_4_cycles, 4);
+    update_slow_turbo_checkboxes(ui, ui->actionSlow_Turbo_4_cycles, 25);
 }
 
 void

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -70,7 +70,7 @@
     </widget>
     <widget class="QMenu" name="menuSlow_turbo">
      <property name="title">
-      <string>Slow Turbo</string>
+      <string>Cycle Skip</string>
      </property>
      <addaction name="actionSlow_Turbo_Off"/>
      <addaction name="actionSlow_Turbo_1_cycle"/>
@@ -390,7 +390,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>1 Cycle</string>
+      <string>1 Cycle Skip</string>
      </property>
     </action>
     <action name="actionSlow_Turbo_2_cycles">
@@ -398,7 +398,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>2 Cycles</string>
+      <string>5 Cycle Skip</string>
      </property>
     </action>
     <action name="actionSlow_Turbo_3_cycles">
@@ -406,7 +406,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>3 Cycles</string>
+      <string>10 Cycle Skip</string>
      </property>
     </action>
     <action name="actionSlow_Turbo_4_cycles">
@@ -414,7 +414,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>4 Cycles</string>
+      <string>25 Cycle Skip</string>
      </property>
     </action>
   <action name="actionExit">


### PR DESCRIPTION
## Summary
- replace "Slow Turbo" menu text with "Cycle Skip"
- offer 1, 5, 10 and 25 cycle skip settings
- update code to handle new cycle skip options

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j2`

------
https://chatgpt.com/codex/tasks/task_e_68557851ae38832f9bf993f0433df275