### PR TITLE
Add hardware summary status bar item

### DIFF
--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -81,6 +81,7 @@ public slots:
     void refreshEmptyIcons();
     void refreshIcons();
     void updateSoundIcon();
+    QString buildHardwareSummary();
 
 private:
     struct States;


### PR DESCRIPTION
## Summary
- extend MachineStatus with hardware summary generation
- show video/sound/storage configuration in the status bar
- list hard disk capacities in the summary

## Testing
- `cmake --preset=regular`
- `cmake --build build/regular`


------
https://chatgpt.com/codex/tasks/task_e_68557e4793c4832fb7c0bf728ba7ce75