### PR TITLE
Fix status bar initialization crash

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -52,6 +52,7 @@ extern volatile int fdcinited;
 #include <QLabel>
 #include <QTimer>
 #include <QStatusBar>
+#include <QVBoxLayout>
 #include <QMenu>
 #include <QScreen>
 #include <QString>
@@ -306,8 +307,9 @@ struct MachineStatus::States {
             n.pixmaps = &pixmaps.net;
         }
 
-        hardware = nullptr;
-        storage  = nullptr;
+        hardware        = nullptr;
+        storage         = nullptr;
+        hardwareWidget  = nullptr;
     }
 
     std::array<StateEmpty, 2>                  cartridge;
@@ -321,6 +323,7 @@ struct MachineStatus::States {
     std::unique_ptr<ClickableLabel>            sound;
     std::unique_ptr<QLabel>                    speed;
     std::unique_ptr<QLabel>                    ram;
+    std::unique_ptr<QWidget>                   hardwareWidget;
     QLabel*                                   hardware;
     QLabel*                                   storage;
     std::unique_ptr<QLabel>                    text;
@@ -861,12 +864,19 @@ MachineStatus::refresh(QStatusBar *sbar)
     }
     sbar->addWidget(d->ram.get());
 
-    d->hardware = sbar->findChild<QLabel*>(QStringLiteral("statusHardwareLabel"));
-    d->storage  = sbar->findChild<QLabel*>(QStringLiteral("statusStorageLabel"));
-    if (d->hardware)
-        d->hardware->setText(buildHardwareSummary());
-    if (d->storage)
-        d->storage->setText(buildStorageSummary());
+    d->hardwareWidget = std::make_unique<QWidget>();
+    auto vlayout       = new QVBoxLayout(d->hardwareWidget.get());
+    vlayout->setSpacing(0);
+    vlayout->setContentsMargins(0, 0, 0, 0);
+
+    d->hardware = new QLabel(d->hardwareWidget.get());
+    d->storage  = new QLabel(d->hardwareWidget.get());
+    vlayout->addWidget(d->hardware);
+    vlayout->addWidget(d->storage);
+
+    d->hardware->setText(buildHardwareSummary());
+    d->storage->setText(buildStorageSummary());
+    sbar->addWidget(d->hardwareWidget.get());
 
     d->text = std::make_unique<QLabel>();
     sbar->addWidget(d->text.get());

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -240,33 +240,7 @@
    <addaction name="menuTools"/>
    <addaction name="menuAbout"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar">
-   <widget class="QWidget" name="statusContainer">
-    <layout class="QVBoxLayout" name="statusLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="statusHardwareLabel"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="statusStorageLabel"/>
-     </item>
-    </layout>
-   </widget>
-  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="contextMenuPolicy">
     <enum>Qt::PreventContextMenu</enum>


### PR DESCRIPTION
## Summary
- initialize the hardware storage labels programmatically
- remove unused UI elements

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6855d6a3c454832f99310227179e876c