### PR TITLE
Revert status bar changes

### DIFF
--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -82,7 +82,6 @@ public slots:
     void refreshIcons();
     void updateSoundIcon();
     QString buildHardwareSummary();
-    QString buildStorageSummary();
 
 private:
     struct States;


### PR DESCRIPTION
## Summary
- revert status bar changes from commits a9f0877de and 6e30638fb
- restore code to match state at commit 62ed6ce70

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6856c536dfc8832f9716c24a047a5448