### PR TITLE
Show media attachments in status bar

### DIFF
--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -83,6 +83,7 @@ public slots:
     void updateSoundIcon();
     QString buildHardwareSummary();
     QString buildStorageSummary();
+    QString buildAttachmentSummary();
 
 private:
     struct States;


### PR DESCRIPTION
## Summary
- extend status bar with a third line to display inserted floppy, disk and CD‑ROM images
- implement `buildAttachmentSummary` to construct the attachment string

## Testing
- `cmake -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6859f85a299c832f8c1915ec52bdefee