### PR TITLE
Add unlimited-speed QUINNEHD disk preset

### DIFF
--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -1387,7 +1387,7 @@ ide_write_data(ide_t *ide, const uint16_t val)
                 const double xfer_time = ide_get_xfer_time(ide, 512);
                 const double wait_time = seek_time + xfer_time;
                 if (ide->command == WIN_WRITE_MULTIPLE) {
-                    if (hdd[ide->hdd_num].speed_preset == 0) {
+                    if (hdd[ide->hdd_num].speed_preset == 0 || hdd[ide->hdd_num].rpm == 0) {
                         ide->pending_delay = 0;
                         ide_callback(ide);
                     } else if ((ide->blockcount + 1) >= ide->blocksize || ide->tf->secount == 1) {
@@ -1746,7 +1746,7 @@ ide_writeb(uint16_t addr, uint8_t val, void *priv)
                         ide->sc->callback = 100.0 * IDE_TIME;
                         ide_set_callback(ide, 100.0 * IDE_TIME);
                     } else {
-                        if (hdd[ide->hdd_num].speed_preset == 0)
+                        if (hdd[ide->hdd_num].speed_preset == 0 || hdd[ide->hdd_num].rpm == 0)
                             ide_set_callback(ide, 100.0 * IDE_TIME);
                         else {
                             double seek_time = hdd_seek_get_time(&hdd[ide->hdd_num], (val & 0x60) ?
@@ -1795,7 +1795,7 @@ ide_writeb(uint16_t addr, uint8_t val, void *priv)
                                                                ide_get_sector(ide), sec_count);
                             double xfer_time = ide_get_xfer_time(ide, 512 * sec_count);
                             wait_time        = seek_time > xfer_time ? seek_time : xfer_time;
-                        } else if ((val == WIN_READ_MULTIPLE) && (hdd[ide->hdd_num].speed_preset == 0)) {
+                        } else if ((val == WIN_READ_MULTIPLE) && (hdd[ide->hdd_num].speed_preset == 0 || hdd[ide->hdd_num].rpm == 0)) {
                            ide_set_callback(ide, 200.0 * IDE_TIME);
                            ide->do_initial_read = 1;
                            break;
@@ -1995,7 +1995,7 @@ ide_read_data(ide_t *ide)
                     ide_next_sector(ide);
                     ide->tf->atastat = BSY_STAT | READY_STAT | DSC_STAT;
                     if (ide->command == WIN_READ_MULTIPLE) {
-                        if (hdd[ide->hdd_num].speed_preset == 0)
+                        if (hdd[ide->hdd_num].speed_preset == 0 || hdd[ide->hdd_num].rpm == 0)
                             ide_callback(ide);
                         else if (!ide->blockcount) {
                             uint32_t cnt = ide->tf->secount ?

--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -138,7 +138,7 @@ hdd_is_valid(int c)
 double
 hdd_seek_get_time(hard_disk_t *hdd, uint32_t dst_addr, uint8_t operation, uint8_t continuous, double max_seek_time)
 {
-    if (!hdd->speed_preset)
+    if (!hdd->speed_preset || !hdd->rpm)
         return HDD_OVERHEAD_TIME;
 
     const hdd_zone_t *zone = NULL;
@@ -263,7 +263,7 @@ hdd_timing_write(hard_disk_t *hdd, uint32_t addr, uint32_t len)
     double   seek_time = 0.0;
     uint32_t flush_needed;
 
-    if (!hdd->speed_preset)
+    if (!hdd->speed_preset || !hdd->rpm)
         return HDD_OVERHEAD_TIME;
 
     hdd_readahead_update(hdd);
@@ -301,7 +301,7 @@ hdd_timing_read(hard_disk_t *hdd, uint32_t addr, uint32_t len)
 {
     double seek_time = 0.0;
 
-    if (!hdd->speed_preset)
+    if (!hdd->speed_preset || !hdd->rpm)
         return HDD_OVERHEAD_TIME;
 
     hdd_readahead_update(hdd);
@@ -542,6 +542,7 @@ static hdd_preset_t hdd_speed_presets[] = {
     { .name = "[ATA-5] Seagate U8 - 17.2gb",                      .internal_name = "ST317221A", .model = "ST317221A", .zones =  16,  .avg_spt = 289, .heads = 3, .rpm = 5400, .full_stroke_ms = 25, .track_seek_ms = 1.5,   .rcache_num_seg =  16, .rcache_seg_size =  512, .max_multiple =  32 },
     { .name = "[ATA-5] Western Digital Caviar 102AA",             .internal_name = "WD102AA", .model = "WDC WD102AA-00ANA0", .zones =  16,  .avg_spt = 295, .heads = 8, .rpm = 5400, .full_stroke_ms = 12, .track_seek_ms = 1.5,   .rcache_num_seg =  16, .rcache_seg_size =  512, .max_multiple =  32 },
     { .name = "[ATA-5] Western Digital Expert",                   .internal_name = "WD135BA", .model = "WDC WD135BA-60AK", .zones =  16,  .avg_spt = 350, .heads = 6, .rpm = 7200, .full_stroke_ms = 15, .track_seek_ms = 2,   .rcache_num_seg =  16, .rcache_seg_size =  1920, .max_multiple =  32 },
+    { .name = "[Special] QUINNEHD (no speed limit)",               .internal_name = "quinnehd", .model = "QUINNEHD", .rcache_num_seg = 16, .rcache_seg_size = 128, .max_multiple = 32 },
    // clang-format on
 };
 
@@ -602,7 +603,7 @@ hdd_preset_apply(int hdd_id)
     if (preset->model)
         hd->model = preset->model;
 
-    if (!hd->speed_preset)
+    if (!hd->speed_preset || !preset->rpm)
         return;
 
     hd->phy_heads = preset->heads;


### PR DESCRIPTION
## Summary
- add new "QUINNEHD" disk preset to disable timing limitations
- treat disks with rpm=0 as unlimited speed
- allow IDE controller to skip delays when rpm is zero

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685a01932240832fb3137aca3acba697