### PR TITLE
Enable virtualize mode for NDR when turbo is active

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -741,6 +741,12 @@ exec386_dynarec(int32_t cycs)
 
     int32_t cyc_period = cycs / 2000; /*5us*/
 
+    if (ndr_virtualize_mode) {
+        exec386_dynarec_dyn();
+        cycles_main -= cycs;
+        return;
+    }
+
 #    ifdef USE_ACYCS
     acycs = 0;
 #    endif

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -271,6 +271,13 @@ CPU          *cpu_s;
 
 uint8_t do_translate  = 0;
 uint8_t do_translate2 = 0;
+int      ndr_virtualize_mode = 0;
+
+void
+cpu_set_ndr_virtualize(int enable)
+{
+    ndr_virtualize_mode = enable;
+}
 
 void (*cpu_exec)(int32_t cycs);
 

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -713,6 +713,8 @@ extern void cpu_set_isa_speed(int speed);
 extern void cpu_set_pci_speed(int speed);
 extern void cpu_set_isa_pci_div(int div);
 extern void cpu_set_agp_speed(int speed);
+extern int  ndr_virtualize_mode;
+extern void cpu_set_ndr_virtualize(int enable);
 
 extern void cpu_CPUID(void);
 extern void cpu_RDMSR(void);

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -442,6 +442,7 @@ main_thread_fn()
     while (!is_quit && cpu_thread_run) {
         /* See if it is time to run a frame of code. */
         const uint64_t new_time = elapsed_timer.elapsed();
+        cpu_set_ndr_virtualize(turbo_mode || turbo_slow_cycles > 0);
 #ifdef USE_GDBSTUB
         if (gdbstub_next_asap && (drawits <= 0))
             drawits = 10;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -35,6 +35,7 @@
 
 extern "C" {
 #include <86box/86box.h>
+#include "cpu.h"
 #include <86box/config.h>
 #include <86box/keyboard.h>
 #include <86box/plat.h>
@@ -1137,6 +1138,7 @@ MainWindow::on_actionTurbo_mode_triggered()
     turbo_mode ^= 1;
     ui->actionTurbo_mode->setChecked(turbo_mode > 0 ? true : false);
     ui->menuSlow_turbo->setEnabled(turbo_mode == 0);
+    cpu_set_ndr_virtualize(turbo_mode || turbo_slow_cycles > 0);
 }
 
 void
@@ -1770,6 +1772,7 @@ update_slow_turbo_checkboxes(Ui::MainWindow *ui, QAction *selected, int value)
     ui->actionSlow_Turbo_4_cycles->setChecked(ui->actionSlow_Turbo_4_cycles == selected);
 
     turbo_slow_cycles = value;
+    cpu_set_ndr_virtualize(turbo_mode || turbo_slow_cycles > 0);
 }
 
 void

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -556,6 +556,7 @@ main_thread(UNUSED(void *param))
     while (!is_quit && cpu_thread_run) {
         /* See if it is time to run a frame of code. */
         new_time = SDL_GetTicks();
+        cpu_set_ndr_virtualize(turbo_mode || turbo_slow_cycles > 0);
 #ifdef USE_GDBSTUB
         if (gdbstub_next_asap && (drawits <= 0))
             drawits = 10;


### PR DESCRIPTION
## Summary
- add `cpu_set_ndr_virtualize` to control a new NDR virtualization mode
- toggle NDR virtualization when turbo/slow turbo is active
- call the toggle from the Qt and Unix front‑ends
- run the dynamic recompiler in virtualization mode when enabled

## Testing
- `cmake --preset regular`
- `cmake --build build/regular`

------
https://chatgpt.com/codex/tasks/task_e_685a9fc89bcc832f8e01fae12dfa792f