### PR TITLE
Fix macOS build regression from virtualization toggle

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -442,7 +442,9 @@ main_thread_fn()
     while (!is_quit && cpu_thread_run) {
         /* See if it is time to run a frame of code. */
         const uint64_t new_time = elapsed_timer.elapsed();
+#ifndef __APPLE__
         cpu_set_ndr_virtualize(virtualized_cpu && (turbo_mode || turbo_slow_cycles > 0));
+#endif
 #ifdef USE_GDBSTUB
         if (gdbstub_next_asap && (drawits <= 0))
             drawits = 10;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1147,7 +1147,9 @@ MainWindow::on_actionTurbo_mode_triggered()
         virtualized_cpu = 0;
         ui->actionVirtualized_CPU->setChecked(false);
     }
+#ifndef __APPLE__
     cpu_set_ndr_virtualize(virtualized_cpu && allowed);
+#endif
 }
 
 void
@@ -1185,7 +1187,9 @@ MainWindow::on_actionVirtualized_CPU_triggered()
 {
     virtualized_cpu ^= 1;
     ui->actionVirtualized_CPU->setChecked(virtualized_cpu > 0 ? true : false);
+#ifndef __APPLE__
     cpu_set_ndr_virtualize(virtualized_cpu && (turbo_mode || turbo_slow_cycles > 0));
+#endif
 }
 
 void
@@ -1789,7 +1793,9 @@ update_slow_turbo_checkboxes(Ui::MainWindow *ui, QAction *selected, int value)
     ui->actionSlow_Turbo_4_cycles->setChecked(ui->actionSlow_Turbo_4_cycles == selected);
 
     turbo_slow_cycles = value;
+#ifndef __APPLE__
     cpu_set_ndr_virtualize(virtualized_cpu && (turbo_mode || turbo_slow_cycles > 0));
+#endif
     const bool allowed = turbo_mode || turbo_slow_cycles > 0;
     ui->actionVirtualized_CPU->setEnabled(allowed);
     if (!allowed) {

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -556,7 +556,9 @@ main_thread(UNUSED(void *param))
     while (!is_quit && cpu_thread_run) {
         /* See if it is time to run a frame of code. */
         new_time = SDL_GetTicks();
+#ifndef __APPLE__
         cpu_set_ndr_virtualize(virtualized_cpu && (turbo_mode || turbo_slow_cycles > 0));
+#endif
 #ifdef USE_GDBSTUB
         if (gdbstub_next_asap && (drawits <= 0))
             drawits = 10;


### PR DESCRIPTION
## Summary
- prevent macOS builds from calling the dynarec virtualization helper

## Testing
- `cmake --build . -j4`

------
https://chatgpt.com/codex/tasks/task_e_685ac6bc1b90832f8f300202f197a5ed