### PR TITLE
Fix macOS build error due to cycles macro

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -129,9 +129,12 @@ extern bool cpu_thread_running;
 #    include "cocoa_keyboard.hpp"
 // The namespace is required to avoid clashing typedefs; we only use this
 // header for its #defines anyway.
+#    pragma push_macro("cycles")
+#    undef cycles
 namespace IOKit {
 #    include <IOKit/hidsystem/IOLLEvent.h>
 }
+#    pragma pop_macro("cycles")
 #endif
 
 #ifdef __HAIKU__


### PR DESCRIPTION
## Summary
- wrap the IOKit header include in `qt_mainwindow.cpp` with `#pragma push_macro`/`pop_macro` to avoid `cycles` macro clash on macOS

## Testing
- `cmake -S . -B build -DHEADLESS=ON`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685acdce8314832fb974c5c65ac7278c