### PR TITLE
Bundle autobuilds into single release

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -156,26 +156,23 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=autobuild-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "tag=autobuild-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_OUTPUT"
           fi
-
-      # ─── create the release shell ───────────────────
-      - uses: actions/create-release@v1
-        id: create
-        name: Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name:      ${{ steps.vars.outputs.tag }}
-          release_name: "Linux nightly – ${{ steps.vars.outputs.tag }}"
-          draft: false
-          prerelease: false
 
       # ─── install zip + gh cli ───────────────────────
       - name: Install zip & gh
         run: |
           sudo apt-get update -y
           sudo apt-get install -y zip gh
+
+      # ─── ensure a single release ────────────────────
+      - name: Ensure GitHub release exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.vars.outputs.tag }}"
+          gh release view "$tag" >/dev/null 2>&1 || \
+          gh release create "$tag" --title "86Box nightly – $tag" --notes ""
 
       # ─── zip each artifact dir and upload ───────────
       - name: Zip and upload assets

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -243,26 +243,23 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=autobuild-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "tag=autobuild-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_OUTPUT"
           fi
-
-      # ─── create the release shell ───────────────────
-      - uses: actions/create-release@v1
-        id: create
-        name: Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name:      ${{ steps.vars.outputs.tag }}
-          release_name: "macOS nightly – ${{ steps.vars.outputs.tag }}"
-          draft: false
-          prerelease: false
 
       # ─── install zip + gh cli ───────────────────────
       - name: Install zip & gh
         run: |
           sudo apt-get update -y
           sudo apt-get install -y zip gh
+
+      # ─── ensure a single release ────────────────────
+      - name: Ensure GitHub release exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.vars.outputs.tag }}"
+          gh release view "$tag" >/dev/null 2>&1 || \
+          gh release create "$tag" --title "86Box nightly – $tag" --notes ""
 
       # ─── zip each artifact dir and upload ───────────
       - name: Zip and upload assets

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -120,26 +120,23 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=autobuild-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "tag=autobuild-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_OUTPUT"
           fi
-
-      # ─── create the release shell ───────────────────
-      - uses: actions/create-release@v1
-        id: create
-        name: Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name:      ${{ steps.vars.outputs.tag }}
-          release_name: "Windows nightly – ${{ steps.vars.outputs.tag }}"
-          draft: false
-          prerelease: false
 
       # ─── install zip + gh cli ───────────────────────
       - name: Install zip & gh
         run: |
           sudo apt-get update -y
           sudo apt-get install -y zip gh
+
+      # ─── ensure a single release ────────────────────
+      - name: Ensure GitHub release exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.vars.outputs.tag }}"
+          gh release view "$tag" >/dev/null 2>&1 || \
+          gh release create "$tag" --title "86Box nightly – $tag" --notes ""
 
       # ─── zip each artifact dir and upload ───────────
       - name: Zip and upload assets


### PR DESCRIPTION
## Summary
- ensure each OS workflow reuses the same GitHub release
- build nightly tag using commit hash instead of workflow run number

## Testing
- `cmake --version`


------
https://chatgpt.com/codex/tasks/task_e_685ae856b830832fa12f8e33cbee22ff