### PR TITLE
Fix virtualized CPU execution

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -741,11 +741,8 @@ exec386_dynarec(int32_t cycs)
 
     int32_t cyc_period = cycs / 2000; /*5us*/
 
-    if (ndr_virtualize_mode) {
-        exec386_dynarec_dyn();
-        cycles_main -= cycs;
-        return;
-    }
+    if (ndr_virtualize_mode)
+        cyc_period = cycs;
 
 #    ifdef USE_ACYCS
     acycs = 0;


### PR DESCRIPTION
## Summary
- prevent VM hang when Virtualized CPU is enabled
- allow dynarec code to run normally with a larger cycle period

## Testing
- `cmake ..`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_685b0049f514832fa22d80caf6e40da7