### PR TITLE
Fix release workflow tag sharing

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -132,6 +132,9 @@ jobs:
   release:
     name: Publish Linux Release
     needs: linux
+    concurrency:
+      group: release-${{ github.sha }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     # Run on manual dispatch or any push (skip only on PRs)

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -187,6 +187,9 @@ jobs:
   release:
     name: Publish macOS Release
     needs: [macos13-x86_64, macos14-arm64]
+    concurrency:
+      group: release-${{ github.sha }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     # Run on manual dispatch or any push (skip only on PRs)

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -132,6 +132,9 @@ jobs:
   release:
     name: Publish Windows Release
     needs: msys2
+    concurrency:
+      group: release-${{ github.sha }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     # Run on manual dispatch or any push (skip only on PRs)


### PR DESCRIPTION
## Summary
- add concurrency group per commit for each release job

## Testing
- `cmake -S . -B build`
- `make -C build -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68680c7e3024832f97fa80e7b9d19617