### PR TITLE
Define force_constant_mouse to fix LLVM/GCC builds

### DIFF
--- a/src/device/mouse.c
+++ b/src/device/mouse.c
@@ -46,6 +46,8 @@ int mouse_timed = 1;
 int mouse_tablet_in_proximity = 0;
 int tablet_tool_type          = 1; /* 0 = Puck/Cursor, 1 = Pen */
 
+int force_constant_mouse       = 0; /* Force constant updating of the mouse */
+
 double mouse_x_abs;
 double mouse_y_abs;
 


### PR DESCRIPTION
## Summary
- define global `force_constant_mouse` to prevent undefined symbol link failures when building

## Testing
- `cmake --build build_noqt -j 4` *(fails: none; build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68aa327f9f70832f8cb086c219ef1d11