### PR TITLE
Ensure artifacts upload even on partial build failures

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.environment.runner }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         build:
 #          - name: Regular
@@ -121,10 +121,12 @@ jobs:
           cmake --install build
 
       - name: Upload artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-UbuntuJammy${{ matrix.environment.slug }}-gha${{ github.run_number }}'
           path: build/artifacts/**
+          if-no-files-found: ignore
 
 # ────────────────────────────────────────────────────────────────
 # 2️⃣  RELEASE JOB  – zips each artifact, then uploads

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-13
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         build:
 #          - name: Regular
@@ -99,10 +99,12 @@ jobs:
         run: cmake --install build
 
       - name: Upload artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-macOS-x86_64-gha${{ github.run_number }}'
           path: build/artifacts/**
+          if-no-files-found: ignore
 
   macos14-arm64:
 
@@ -111,7 +113,7 @@ jobs:
     runs-on: macos-14
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         build:
 #          - name: Regular
@@ -176,10 +178,12 @@ jobs:
         run: cmake --install build
 
       - name: Upload artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-macOS-arm64-gha${{ github.run_number }}'
           path: build/artifacts/**
+          if-no-files-found: ignore
 
 # ────────────────────────────────────────────────────────────────
 # 2️⃣  RELEASE JOB  – zips each artifact, then uploads

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -39,7 +39,7 @@ jobs:
         shell: msys2 {0}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         build:
 #          - name: Regular
@@ -120,11 +120,13 @@ jobs:
       - name: Generate package
         run: cmake --install build
 
-      - uses: actions/upload-artifact@v4
-        name: Upload artifact
+      - name: Upload artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
         with:
           name: 86Box${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-Windows${{ matrix.environment.slug }}-gha${{ github.run_number }}
           path: build/artifacts/**
+          if-no-files-found: ignore
 
 # ────────────────────────────────────────────────────────────────
 # 2️⃣  RELEASE JOB  – zips each artifact, then uploads


### PR DESCRIPTION
## Summary
- ensure workflow matrices continue after failures
- upload build artifacts even if earlier steps failed

## Testing
- `pip install yamllint`
- `yamllint -d "{extends: default, rules: {line-length: {max: 300}, document-start: disable, comments-indentation: disable, truthy: disable, comments: disable, colons: disable, braces: disable}}" .github/workflows/cmake_linux.yml .github/workflows/cmake_macos.yml .github/workflows/cmake_windows_msys2.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aa5ff1cf90832fa1ec40adbd7683aa