### PR TITLE
Fix Qt build headers and RDISK_NUM definition

### DIFF
--- a/src/include/86box/machine_status.h
+++ b/src/include/86box/machine_status.h
@@ -1,6 +1,14 @@
 #ifndef EMU_MACHINE_STATUS_H
 #define EMU_MACHINE_STATUS_H
 
+#include <86box/plat.h>
+#include <86box/fdd.h>
+#include <86box/cdrom.h>
+#include <86box/rdisk.h>
+#include <86box/mo.h>
+#include <86box/hdd.h>
+#include <86box/network.h>
+
 typedef struct dev_status_empty_active_t {
     atomic_bool_t empty;
     atomic_bool_t active;

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -34,7 +34,6 @@ extern "C" {
 #include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/sound.h>
-#include <86box/zip.h>
 #include <86box/mo.h>
 #include <86box/plat.h>
 #include <86box/machine.h>


### PR DESCRIPTION
## Summary
- include platform and storage headers in machine_status.h to expose RDISK_NUM
- drop unused zip.h include from Qt machine status

## Testing
- `cmake -S . -B build`
- `cmake --build build --target ui -j2`
- `gcc -std=c11 -I src/include -I build/src/include -c src/machine_status.c`


------
https://chatgpt.com/codex/tasks/task_e_68aa5fa7b4f0832f98466d235989bf97