### PR TITLE
Ensure macOS app binaries are executable

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -98,6 +98,10 @@ jobs:
       - name: Generate package
         run: cmake --install build
 
+      - name: Fix app permissions
+        run: |
+          find build/artifacts -path "*.app/Contents/MacOS/*" -exec chmod +x {} \;
+
       - name: Upload artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -176,6 +180,10 @@ jobs:
 
       - name: Generate package
         run: cmake --install build
+
+      - name: Fix app permissions
+        run: |
+          find build/artifacts -path "*.app/Contents/MacOS/*" -exec chmod +x {} \;
 
       - name: Upload artifact
         if: ${{ always() }}

--- a/.github/workflows/codeql_macos.yml
+++ b/.github/workflows/codeql_macos.yml
@@ -118,6 +118,10 @@ jobs:
         run: |
           build-wrapper-macosx-x86 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build
 
+      - name: Fix app permissions
+        run: |
+          find build -path "*.app/Contents/MacOS/*" -exec chmod +x {} \;
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:


### PR DESCRIPTION
## Summary
- Ensure macOS build workflow sets executable bit for app bundle binaries
- Add the same permission fix to the macOS CodeQL workflow

## Testing
- `yamllint .github/workflows/cmake_macos.yml .github/workflows/codeql_macos.yml` *(fails: multiple style warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa71e23028832f8c5bc0aa16fe1424