### PR TITLE
CI: add ad-hoc signing for macOS builds

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -100,7 +100,13 @@ jobs:
 
       - name: Fix app permissions
         run: |
-          find build/artifacts -path "*.app/Contents/MacOS/*" -exec chmod +x {} \;
+          find build/artifacts -path "*.app/Contents/MacOS/*" -type f -exec chmod +x {} \;
+
+      - name: Ad-hoc sign app
+        run: |
+          for app in build/artifacts/*.app; do
+            codesign --force --deep -s - "$app"
+          done
 
       - name: Upload artifact
         if: ${{ always() }}
@@ -183,7 +189,13 @@ jobs:
 
       - name: Fix app permissions
         run: |
-          find build/artifacts -path "*.app/Contents/MacOS/*" -exec chmod +x {} \;
+          find build/artifacts -path "*.app/Contents/MacOS/*" -type f -exec chmod +x {} \;
+
+      - name: Ad-hoc sign app
+        run: |
+          for app in build/artifacts/*.app; do
+            codesign --force --deep -s - "$app"
+          done
 
       - name: Upload artifact
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- add a codesign step to macOS workflows for ad-hoc signing
- ensure Contents/MacOS files are executable before signing

## Testing
- `yamllint .github/workflows/cmake_macos.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ab078a9a60832fb3e09d94224fc856