### PR TITLE
ci: run all platform builds on every push

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -4,15 +4,6 @@ on:
 
   workflow_dispatch:
   push:
-    paths:
-      - src/**
-      - cmake/**
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "!.github/workflows/**"
-      - .github/workflows/cmake_linux.yml
-      - vcpkg.json
-      - "!**/Makefile*"
 
   pull_request:
     paths:

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -4,15 +4,6 @@ on:
 
   workflow_dispatch:
   push:
-    paths:
-      - src/**
-      - cmake/**
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "!.github/workflows/**"
-      - .github/workflows/cmake_macos.yml
-      - vcpkg.json
-      - "!**/Makefile*"
 
   pull_request:
     paths:

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -3,15 +3,6 @@ name: CMake (Windows, msys2)
 on:
   workflow_dispatch:
   push:
-    paths:
-      - src/**
-      - cmake/**
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "!.github/workflows/**"
-      - .github/workflows/cmake_windows_msys2.yml
-      - vcpkg.json
-      - "!**/Makefile*"
 
   pull_request:
     paths:


### PR DESCRIPTION
## Summary
- trigger macOS, Linux and Windows builds on any push

## Testing
- `actionlint .github/workflows/cmake_linux.yml .github/workflows/cmake_macos.yml .github/workflows/cmake_windows_msys2.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ab32af7184832fb3d7ed372f504e02